### PR TITLE
test(it01|r2-hu01): cambios menores en servicioLugares + servicioAPIs

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -8,6 +8,9 @@
       <SelectionState runConfigName="addLugar_R2HU01_darDeAltaLugarOK()">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="ServicioLugaresTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/androidTest/java/es/uji/smallaris/model/TestServicioLugares.kt
+++ b/app/src/androidTest/java/es/uji/smallaris/model/TestServicioLugares.kt
@@ -6,15 +6,15 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 
-class ServicioLugaresTest {
+class TestServicioLugares {
 
     @Test
     fun addLugar_R2HU01_darDeAltaLugarOK() {
         // Given
-        val servicioAPIs = ServicioAPIs()
+        val servicioAPIs = ServicioAPIs
         assert(servicioAPIs.apiEnFuncionamiento(API.TOPONIMO))
-        val repositorioLugares: RepositorioLugares = repositorioFirebase()
-        val servicioLugares = ServicioLugares(repositorioLugares, mutableListOf(), servicioAPIs)
+        val repositorioLugares: RepositorioLugares = RepositorioFirebase()
+        val servicioLugares = ServicioLugares(repositorioLugares, servicioAPIs)
 
         // When
         val resultado = servicioLugares.addLugar(-0.0376709F, 39.986F)
@@ -30,10 +30,10 @@ class ServicioLugaresTest {
         var resultado: UbicationErrorException? = null
 
         // Given
-        val servicioAPIs = ServicioAPIs()
+        val servicioAPIs = ServicioAPIs
         assert(servicioAPIs.apiEnFuncionamiento(API.TOPONIMO))
-        val repositorioLugares: RepositorioLugares = repositorioFirebase()
-        val servicioLugares = ServicioLugares(repositorioLugares, mutableListOf(), servicioAPIs)
+        val repositorioLugares: RepositorioLugares = RepositorioFirebase()
+        val servicioLugares = ServicioLugares(repositorioLugares, servicioAPIs)
         servicioLugares.addLugar(-0.0376709F, 39.986F, "Castellón de la Plana")
 
         // When
@@ -56,10 +56,10 @@ class ServicioLugaresTest {
         var resultado: UbicationErrorException? = null
 
         // Given
-        val servicioAPIs = ServicioAPIs()
+        val servicioAPIs = ServicioAPIs
         assert(servicioAPIs.apiEnFuncionamiento(API.TOPONIMO))
-        val repositorioLugares: RepositorioLugares = repositorioFirebase()
-        val servicioLugares = ServicioLugares(repositorioLugares, mutableListOf(), servicioAPIs)
+        val repositorioLugares: RepositorioLugares = RepositorioFirebase()
+        val servicioLugares = ServicioLugares(repositorioLugares, servicioAPIs)
 
         // When
         try {
@@ -80,10 +80,10 @@ class ServicioLugaresTest {
         var resultado: UbicationErrorException? = null
 
         // Given
-        val servicioAPIs = ServicioAPIs()
+        val servicioAPIs = ServicioAPIs
         assert(servicioAPIs.apiEnFuncionamiento(API.TOPONIMO))
-        val repositorioLugares: RepositorioLugares = repositorioFirebase()
-        val servicioLugares = ServicioLugares(repositorioLugares, mutableListOf(), servicioAPIs)
+        val repositorioLugares: RepositorioLugares = RepositorioFirebase()
+        val servicioLugares = ServicioLugares(repositorioLugares, servicioAPIs)
 
         // When
         try {

--- a/app/src/main/java/es/uji/smallaris/model/RepositorioFirebase.kt
+++ b/app/src/main/java/es/uji/smallaris/model/RepositorioFirebase.kt
@@ -1,6 +1,6 @@
 package es.uji.smallaris.model
 
-class repositorioFirebase : RepositorioLugares {
+class RepositorioFirebase : RepositorioLugares {
     override fun getLugares(): List<LugarInteres> {
         return mutableListOf()
     }

--- a/app/src/main/java/es/uji/smallaris/model/ServicioAPIs.kt
+++ b/app/src/main/java/es/uji/smallaris/model/ServicioAPIs.kt
@@ -1,6 +1,6 @@
 package es.uji.smallaris.model
 
-class ServicioAPIs {
+object ServicioAPIs {
 
     public fun getToponimoCercano(longitud: Float, latitud: Float): String {
         return ""

--- a/app/src/main/java/es/uji/smallaris/model/ServicioLugares.kt
+++ b/app/src/main/java/es/uji/smallaris/model/ServicioLugares.kt
@@ -4,14 +4,13 @@ import kotlin.jvm.Throws
 
 class ServicioLugares(
     private val repositorioLugares: RepositorioLugares,
-    lugares: MutableList<LugarInteres>,
     private val apiObtenerNombres: ServicioAPIs
 ) {
 
     private val lugares = mutableListOf<LugarInteres>()
 
     init {
-        this.lugares.addAll(lugares)
+        this.lugares.addAll(repositorioLugares.getLugares())
     }
 
     @Throws(UbicationErrorException::class)


### PR DESCRIPTION
**Cambios en ServicioLugares:**

-  eliminado el parámetro del constructor para insertar la lista de lugares, ahora se obtiene directamente del repositorio remoto 

**Cambios en ServicioAPIs:**

- cambiado a object, se tratará a partir de ahora como un Singleton 

**Cambios de nombres:**

- corregida errata de primera en mayúscula para la clase repostorioFirebase
- corregido nombre del test de servicio lugares, la palabra test siempre debe aparecer delante